### PR TITLE
일부 Basic Latin 문자 수정

### DIFF
--- a/lib/neodgm/bitmap_font/basic_latin.ex
+++ b/lib/neodgm/bitmap_font/basic_latin.ex
@@ -1879,8 +1879,8 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 0
       xmax 7
-      ymin 9
-      ymax 11
+      ymin 4
+      ymax 6
 
       data """
       0111011

--- a/lib/neodgm/bitmap_font/basic_latin.ex
+++ b/lib/neodgm/bitmap_font/basic_latin.ex
@@ -142,16 +142,16 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
 
     glyph unicode: ?' do
       advance 8
-      xmin 1
-      xmax 4
+      xmin 3
+      xmax 5
       ymin 7
       ymax 11
 
       data """
-      011
-      011
-      011
-      110
+      11
+      11
+      11
+      10
       """
     end
 
@@ -159,11 +159,12 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 2
       xmax 6
-      ymin 0
-      ymax 10
+      ymin -2
+      ymax 11
 
       data """
-      0111
+      0011
+      0110
       1100
       1100
       1100
@@ -172,7 +173,9 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       1100
       1100
       1100
-      0111
+      1100
+      0110
+      0011
       """
     end
 
@@ -180,11 +183,12 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 2
       xmax 6
-      ymin 0
-      ymax 10
+      ymin -2
+      ymax 11
 
       data """
-      1110
+      1100
+      0110
       0011
       0011
       0011
@@ -193,7 +197,9 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       0011
       0011
       0011
-      1110
+      0011
+      0110
+      1100
       """
     end
 
@@ -1183,11 +1189,14 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 2
       xmax 6
-      ymin 0
-      ymax 10
+      ymin -2
+      ymax 11
 
       data """
       1111
+      1100
+      1100
+      1100
       1100
       1100
       1100
@@ -1223,11 +1232,14 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 2
       xmax 6
-      ymin 0
-      ymax 10
+      ymin -2
+      ymax 11
 
       data """
       1111
+      0011
+      0011
+      0011
       0011
       0011
       0011
@@ -1795,15 +1807,18 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 1
       xmax 7
-      ymin 0
-      ymax 10
+      ymin -2
+      ymax 11
 
       data """
       000111
       001100
       001100
       001100
+      001100
+      001100
       111000
+      001100
       001100
       001100
       001100
@@ -1816,10 +1831,13 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 3
       xmax 5
-      ymin 0
-      ymax 10
+      ymin -2
+      ymax 11
 
       data """
+      11
+      11
+      11
       11
       11
       11
@@ -1837,15 +1855,18 @@ defmodule NeoDGM.BitmapFont.BasicLatin do
       advance 8
       xmin 1
       xmax 7
-      ymin 0
-      ymax 10
+      ymin -2
+      ymax 11
 
       data """
       111000
       001100
       001100
       001100
+      001100
+      001100
       000111
+      001100
       001100
       001100
       001100


### PR DESCRIPTION
- 위쪽 끝과 아래쪽 끝이 각각 라틴 문자의 capHeight와 baseline에 맞춰져 있던 일부 기호를 위아래로 늘려서 한글 텍스트와 라틴 텍스트에서 모두 보기 좋도록 수정합니다.
    - `( U+0028 LEFT PARENTHESIS`
    - `) U+0029 RIGHT PARENTHESIS`
    - `[ U+005B LEFT SQUARE BRACKET`
    - `] U+005D RIGHT SQUARE BRACKET`
    - `{ U+007B LEFT CURLY BRACKET`
    - `| U+007C VERTICAL LINE`
    - `} U+007D RIGHT CURLY BRACKET`

- `' U+0027 APOSTROPHE` 문자의 모양과 위치를 수정합니다.

- `~ U+007E TILDE` 문자의 세로 위치를 상단에서 중간으로 이동합니다.

## 미리보기

![20191001](https://user-images.githubusercontent.com/2667858/65956846-525ba880-e486-11e9-895c-d50d66a5be49.png)
